### PR TITLE
Add homebridge -P option to allow for local plugin development

### DIFF
--- a/image/run.sh
+++ b/image/run.sh
@@ -5,6 +5,7 @@ sed -i "s/rlimit-nproc=3/#rlimit-nproc=3/" /etc/avahi/avahi-daemon.conf
 cd /root/.homebridge
 package_file="/root/.homebridge/package.json"
 install_file="/root/.homebridge/install.sh"
+plugin_folder="/root/.homebridge/plugins"
 
 # Try to install packages
 if [ -f "$package_file" ]
@@ -27,4 +28,4 @@ rm -f /var/run/dbus/pid /var/run/avahi-daemon/pid
 dbus-daemon --system
 avahi-daemon -D
 
-homebridge
+homebridge -P $plugin_folder


### PR DESCRIPTION
Hi!
Thanks for the great container! I created a tiny addition to allow for local plugins and local plugin development. HomeBridge takes the parameter P to look for plugins in the specified folder (see https://github.com/nfarina/homebridge#plugin-development).

I think it's a great addition to enable everyone to write their own plugins without the need to push them to NPM.

As far as I can tell from the HomeBridge source code there are no negative side effects, even if the folder provided to `-P` does not exist. It should be safe to hard code it like this.

Would be glad if you could add this so I don't have to run my own fork of this.
Thanks!
