### PR TITLE
Updated to debian stretch and added ffmpeg in build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.2
+FROM node:8.4-stretch
 
 MAINTAINER Marco Raddatz
 
@@ -7,7 +7,8 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV TERM xterm
 
 # Install dependencies and tools
-RUN echo "deb http://ftp.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/jessie-backports.list
+# For debian stretch should not be needed
+#RUN echo "deb http://ftp.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/jessie-backports.list
 
 RUN apt-get update; \
     apt-get install -y apt-utils apt-transport-https; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,13 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV TERM xterm
 
 # Install dependencies and tools
+RUN echo "deb http://ftp.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/jessie-backports.list
+
 RUN apt-get update; \
     apt-get install -y apt-utils apt-transport-https; \
     apt-get install -y curl wget; \
     apt-get install -y libnss-mdns avahi-discover libavahi-compat-libdnssd-dev libkrb5-dev; \
+    apt-get install -y ffmpeg; \
     apt-get install -y nano vim
 
 # Install latest Homebridge


### PR DESCRIPTION
It would be good to have it in the build to save boot time in case of using ffmpeg npm homebridge.